### PR TITLE
feat: Prometheus and Grafana 기반 모니터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,18 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
+//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -1,0 +1,37 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    user: "$UID:$GID"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - app-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    user: "$UID:$GID"
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 5s # 5초마다 데이터 수집
+
+scrape_configs:
+  - job_name: 'otboo-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080'] # 로컬 앱 접속 주소
+
+# 도커 네트워크를 사용하는 경우 아래 설정 사용
+#    metrics_path: '/actuator/prometheus'
+#      dns_sd_configs:
+#        - names: ['otboo-app']
+#          type: 'A'
+#          port: 8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=otboo

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: otboo
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, metrics, health
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 📝 작업 내용
- 앱 성능 지표 확인 모니터링 시스템

## 🔗 관련 이슈
- Closes #81

## 📢 리뷰어에게 알릴 사항

### 라이브러리
- actuator, prometheus 추가
- redis, security 관련 설정이 안되어있기 때문에 비활성화

###  Grafana 모니터링 방법
- docker-compose -f docker-compose-monitoring.yml up -d
- localhost:3000 접속
- admin,admin 로그인
- connections-data sources-Add data source-prometheus-connection url( http://prometheus:9090 )-save and test
- dashboards-new dashboard-Import a dashboard-id:11378(대시보드 임포트는 아무거나)-load

### 참고사진
<img width="1614" height="793" alt="image" src="https://github.com/user-attachments/assets/fe896f2d-4847-458f-a98b-fac6f59a2a7c" />
이 외 여러가지 있음

### Prometheus 접속
- localhost:9090